### PR TITLE
Use .NET 4.0 since it doesn't depend on .NET 4.5

### DIFF
--- a/src/JobSharp.Sample/App.config
+++ b/src/JobSharp.Sample/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
   </configSections>
 
   <appSettings>
@@ -12,34 +12,34 @@
     MM = month (1-12)
     ss = day of the week(0-6)
     -->
-    <add key="JobSharp:Crontab" value="1000" />
-    <add key="JobSharp:Jobs" value="ShortRunningJob,ProblematicJob,LongRunningJob" />
-    <add key="ShortRunningJob:Crontab" value="* * * * *" />
-    <add key="ProblematicJob:Crontab" value="* * * * *" />
-    <add key="LongRunningJob:Crontab" value="* * * * *" />
+    <add key="JobSharp:Crontab" value="1000"/>
+    <add key="JobSharp:Jobs" value="ShortRunningJob,ProblematicJob,LongRunningJob"/>
+    <add key="ShortRunningJob:Crontab" value="* * * * *"/>
+    <add key="ProblematicJob:Crontab" value="* * * * *"/>
+    <add key="LongRunningJob:Crontab" value="* * * * *"/>
   </appSettings>
 
   <log4net>
     <appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
-      <file value="Logs/log.txt" />
-      <appendToFile value="true" />
-      <rollingStyle value="Size" />
-      <maxSizeRollBackups value="10" />
-      <maximumFileSize value="100KB" />
-      <staticLogFileName value="true" />
-      <ImmediateFlush value="true" />
+      <file value="Logs/log.txt"/>
+      <appendToFile value="true"/>
+      <rollingStyle value="Size"/>
+      <maxSizeRollBackups value="10"/>
+      <maximumFileSize value="100KB"/>
+      <staticLogFileName value="true"/>
+      <ImmediateFlush value="true"/>
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%d{dd/MM/yy HH:mm:ss} [%level%] %m%newline" />
+        <conversionPattern value="%d{dd/MM/yy HH:mm:ss} [%level%] %m%newline"/>
       </layout>
     </appender>
     <root>
-      <level value="ALL" />
-      <appender-ref ref="RollingFileAppender" />
+      <level value="ALL"/>
+      <appender-ref ref="RollingFileAppender"/>
     </root>
   </log4net>
 
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
   </startup>
 
 </configuration>

--- a/src/JobSharp.Sample/JobSharp.Sample.csproj
+++ b/src/JobSharp.Sample/JobSharp.Sample.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JobSharp.Sample</RootNamespace>
     <AssemblyName>JobSharp.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/JobSharp.UnitTests/JobSharp.UnitTests.csproj
+++ b/src/JobSharp.UnitTests/JobSharp.UnitTests.csproj
@@ -7,7 +7,8 @@
     <OutputType>Library</OutputType>
     <RootNamespace>JobSharp.UnitTests</RootNamespace>
     <AssemblyName>JobSharp.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/JobSharp/JobSharp.csproj
+++ b/src/JobSharp/JobSharp.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JobSharp</RootNamespace>
     <AssemblyName>JobSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I changed the project files to target .NET 4.0. It builds normally and all tests have passed.
